### PR TITLE
fix(checkAllFollowers): be more resilient to sentry errors

### DIFF
--- a/unfollow-ninja-server/src/workers/cacheAllFollowers.ts
+++ b/unfollow-ninja-server/src/workers/cacheAllFollowers.ts
@@ -41,7 +41,11 @@ export async function cacheAllFollowers(workerId: number, nbWorkers: number, dao
         await Promise.all(promises);
         metrics.gauge(`uninja.cache-duration.worker.${workerId}`, Date.now() - startedAt);
     } catch (error) {
-        Sentry.captureException(error);
+        try {
+            Sentry.captureException(error);
+        } catch(sentryError) {
+            logger.error(sentryError);
+        }
         logger.error(error);
     }
 


### PR DESCRIPTION
I catch all errors to avoid to "break" the infinite loop of checking all followers, but when I send these errors to sentry, a network error can break that loop.
Let's catch these errors too