### PR TITLE
feat(locked account): detect locked/limited accounts

### DIFF
--- a/unfollow-ninja-server/locales/en.json
+++ b/unfollow-ninja-server/locales/en.json
@@ -3,11 +3,12 @@
 	"one of you followers": "one of you followers",
 	"{{username}} unfollowed you {{emoji}}.": "{{username}} unfollowed you {{emoji}}.",
 	"{{username}} has been suspended {{emoji}}.": "{{username}} has been suspended {{emoji}}.",
-	"{{username}} has left Twitter {{emoji}}." : "{{username}} has left Twitter {{emoji}}.",
+	"{{username}} has left Twitter {{emoji}}.": "{{username}} has left Twitter {{emoji}}.",
 	"{{username}} blocked you {{emoji}}.": "{{username}} blocked you {{emoji}}.",
 	"You blocked {{username}} {{emoji}}.": "You blocked {{username}} {{emoji}}.",
 	"This account followed you for {{duration}} ({{{time}}}).": "This account followed you for {{duration}} ({{{time}}}).",
 	"This account followed you before you signed up to @unfollowninja!": "This account followed you before you signed up to @unfollowninja!",
 	"and {{nbLeftovers}} more.": "and {{nbLeftovers}} more.",
-	"All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!": "All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!"
+	"All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!": "All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!",
+	"{{username}}'s account has been locked {{emoji}}.": "{{username}}'s account has been locked {{emoji}}."
 }

--- a/unfollow-ninja-server/locales/es.json
+++ b/unfollow-ninja-server/locales/es.json
@@ -9,5 +9,6 @@
 	"This account followed you for {{duration}} ({{{time}}}).": "Esta cuenta te siguió por {{duration}} ({{{time}}}).",
 	"This account followed you before you signed up to @unfollowninja!": "Esta cuenta te seguía antes de que te registrases en @unfollowninja!",
 	"and {{nbLeftovers}} more.": "y {{nbLeftovers}} más.",
-	"All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!": "Todo listo, bienvenido a @unfollowNinja {{emoji}}!\nPronto conocerás todo sobre tus unfollowers!"
+	"All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!": "Todo listo, bienvenido a @unfollowNinja {{emoji}}!\nPronto conocerás todo sobre tus unfollowers!",
+	"{{username}}'s account has been locked {{emoji}}.": "La cuenta de {{username}} ha sido limitada {{emoji}}."
 }

--- a/unfollow-ninja-server/locales/fr.json
+++ b/unfollow-ninja-server/locales/fr.json
@@ -9,5 +9,6 @@
 	"This account followed you for {{duration}} ({{{time}}}).": "Ce compte vous a suivi pendant {{duration}} ({{{time}}}).",
 	"This account followed you before you signed up to @unfollowninja!": "Ce compte vous suivait avant votre inscription à @unfollowninja !",
 	"and {{nbLeftovers}} more.": "et {{nbLeftovers}} autres twittos.",
-	"All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!": "Tout est prêt, bienvenue sur @unfollowNinja {{emoji}} !\nVous allez bientot tout savoir sur vos unfollowers ici !"
+	"All set, welcome to @unfollowNinja {{emoji}}!\nYou will soon know all about your unfollowers here!": "Tout est prêt, bienvenue sur @unfollowNinja {{emoji}} !\nVous allez bientot tout savoir sur vos unfollowers ici !",
+	"{{username}}'s account has been locked {{emoji}}.": "Le compte de {{username}} a été verrouilé {{emoji}}."
 }

--- a/unfollow-ninja-server/package-lock.json
+++ b/unfollow-ninja-server/package-lock.json
@@ -7217,11 +7217,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
-    },
     "lodash.topairs": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
@@ -7791,14 +7786,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
       "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA==",
       "dev": true
-    },
-    "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-      "requires": {
-        "lodash.toarray": "^4.4.0"
-      }
     },
     "node-fetch": {
       "version": "2.6.1",

--- a/unfollow-ninja-server/package.json
+++ b/unfollow-ninja-server/package.json
@@ -66,7 +66,6 @@
     "lodash": "^4.17.20",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.31",
-    "node-emoji": "^1.10.0",
     "oauth": "^0.9.15",
     "p-limit": "^3.0.2",
     "pg": "^8.4.1",

--- a/unfollow-ninja-server/src/tasks/notifyUser.ts
+++ b/unfollow-ninja-server/src/tasks/notifyUser.ts
@@ -2,7 +2,6 @@ import i18n from 'i18n';
 import { Job } from 'kue';
 import { defaults, difference, get, keyBy, split } from 'lodash';
 import moment from 'moment-timezone';
-import emojis from 'node-emoji';
 import { Params, Twitter } from 'twit';
 import { promisify } from 'util';
 import { UserCategory } from '../dao/dao';
@@ -63,6 +62,7 @@ export default class extends Task {
 
         await Promise.all(usersLookup.data.map(user => {
             unfollowersMap[user.id_str].suspended = false;
+            unfollowersMap[user.id_str].locked = (user.friends_count === 0);
             unfollowersMap[user.id_str].username = user.screen_name;
             return this.dao.addTwittoToCache({
                 id: user.id_str,
@@ -189,22 +189,25 @@ export default class extends Task {
             }
             let action;
             if (unfollower.suspended) {
-                const emoji = emojis.get('see_no_evil') + customEmoji;
+                const emoji = '🙈' + customEmoji;
                 action = i18n.__('{{username}} has been suspended {{emoji}}.', { username, emoji });
             } else if (unfollower.deleted) {
-                const emoji = emojis.get('see_no_evil') + customEmoji;
+                const emoji = '🙈' + customEmoji;
                 action = i18n.__('{{username}} has left Twitter {{emoji}}.', { username, emoji });
             } else if (unfollower.blocked_by) {
-                const emoji = emojis.get('no_entry') + customEmoji;
+                const emoji = '⛔️' + customEmoji;
                 action = i18n.__('{{username}} blocked you {{emoji}}.', { username, emoji });
             } else if (unfollower.blocking) {
-                const emoji = emojis.get('poop').repeat(3) + customEmoji;
+                const emoji = '💩💩💩' + customEmoji;
                 action = i18n.__('You blocked {{username}} {{emoji}}.', { username, emoji });
+            } else if (unfollower.locked) {
+                const emoji = '🔒' + (unfollower.following ? customEmoji || '💔' : customEmoji);
+                action = i18n.__('{{username}}\'s account has been locked {{emoji}}.', { username, emoji });
             } else if (unfollower.following) {
-                const emoji = customEmoji || emojis.get('broken_heart');
+                const emoji = customEmoji || '💔';
                 action = i18n.__('{{username}} unfollowed you {{emoji}}.', { username, emoji });
             } else {
-                const emoji = customEmoji || emojis.get('wave');
+                const emoji = customEmoji || '👋';
                 action = i18n.__('{{username}} unfollowed you {{emoji}}.', { username, emoji });
             }
 

--- a/unfollow-ninja-server/src/tasks/sendWelcomeMessage.ts
+++ b/unfollow-ninja-server/src/tasks/sendWelcomeMessage.ts
@@ -1,6 +1,5 @@
 import * as i18n from 'i18n';
 import { Job } from 'kue';
-import * as emojis from 'node-emoji';
 import {Params, Twitter} from 'twit';
 import { promisify } from 'util';
 import {UserCategory} from '../dao/dao';
@@ -19,9 +18,8 @@ export default class extends Task {
         const dmTwit = await userDao.getDmTwit();
         i18n.setLocale(await userDao.getLang());
 
-        const emoji = emojis.get('open_hands');
         const message = i18n.__('All set, welcome to @unfollowNinja {{emoji}}!\n' +
-            'You will soon know all about your unfollowers here!', { emoji });
+            'You will soon know all about your unfollowers here!', { emoji: '🙌' });
 
         await dmTwit.post('direct_messages/events/new', {
             event: {

--- a/unfollow-ninja-server/src/utils/types.ts
+++ b/unfollow-ninja-server/src/utils/types.ts
@@ -13,6 +13,7 @@ export interface IUnfollowerInfo extends IFollowerInfo {
     blocking?: boolean;
     blocked_by?: boolean;
     suspended?: boolean;
+    locked?: boolean;
     deleted?: boolean;
     following?: boolean;
     followed_by?: boolean;


### PR DESCRIPTION
Make the approximation 0 followings = locked account (there may be a better cleaner way but I don't know it for now)

Also, get rid of the node-emoji dependency