### PR TITLE
fix(ioredis): use disconnect instead of quit

### DIFF
--- a/unfollow-ninja-server/jest.config.js
+++ b/unfollow-ninja-server/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     ],
     globals: {
         'ts-jest': {
-            tsConfig: 'tsconfig.json',
+            tsconfig: 'tsconfig.json',
         },
     },
     moduleFileExtensions: [

--- a/unfollow-ninja-server/src/dao/dao.ts
+++ b/unfollow-ninja-server/src/dao/dao.ts
@@ -48,7 +48,7 @@ export default class Dao {
     public async disconnect() {
         await Promise.all([
             this.sequelize.close(),
-            this.redis.quit(),
+            this.redis.disconnect(),
         ]);
     }
 


### PR DESCRIPTION
It looks like since I upgraded the dependencies here https://github.com/PLhery/unfollowNinja/pull/35/files (probably ioredis 4.17>4.19?) docker tests never end

Indeed, the redis connection won't end over a "redis.quit", only with a "redis.disconnect", so i'll change that.

(unrelated bonus: removed a jest warning by changing the deprecated tsConfig into tsconfig)